### PR TITLE
Fix commandInhibitors sorting

### DIFF
--- a/classes/loader.js
+++ b/classes/loader.js
@@ -163,7 +163,7 @@ module.exports = class Loader {
 	}
 
 	sortInhibitors() {
-		this.client.commandInhibitors = this.client.commandInhibitors.sort((low, high) => low.conf.priority < high.conf.priority);
+		this.client.commandInhibitors = this.client.commandInhibitors.array().sort((low, high) => low.conf.priority < high.conf.priority);
 	}
 
 	async loadCommandFinalizers() {


### PR DESCRIPTION
### Proposed Semver Increment Bump: [/PATCH]

### Fixes

```
this.client.commandInhibitors.sort is not a function
    at Loader.sortInhibitors (./komada-classbased/classes/loader.js:166:65)
```